### PR TITLE
AllegroGraph version 7.0.4 Docker image, Kubernetes and Helm features changed/extended.

### DIFF
--- a/README-original.md
+++ b/README-original.md
@@ -1,0 +1,17 @@
+# Welcome to AllegroGraph examples!
+
+This repository contains examples of using AllegroGraph in advanced scenarios.
+
+## Featured examples
+
+* Configuration and setup examples
+  * [Clustering](clustering)
+    * [Load balancing multi-master replication cluster on AWS using Terraform](clustering/terraform-elb/using-terraform.md)
+    * [AllegroGraph Replication using NGINX Load Balancer](clustering/misc/using-nginx-load-balancer.md)
+    * [MMR Replication Clusters in Kubernetes and Docker Swarm](clustering/kubernetes/mmr/kubernetes-mmr.md)
+* Data examples
+  * [Bitcoin RDF model](data/bitcoin)
+
+* Generate AllegroGraph databases
+  * [Weather data](generators/weather/weather.md)
+  

--- a/README.md
+++ b/README.md
@@ -1,17 +1,96 @@
-# Welcome to AllegroGraph examples!
+# Development/Release Notes
 
-This repository contains examples of using AllegroGraph in advanced scenarios.
+Author:     Robert Wydler </br>
+LinkedIn:   [Profile](https://www.linkedin.com/in/robwyd/) 
 
-## Featured examples
+## Introduction 
+### Based on ###
+ This is an extension of the product "AllegroGraph for Multi-Master Replication" and is based on https://github.com/franzinc/agraph-examples.
 
-* Configuration and setup examples
-  * [Clustering](clustering)
-    * [Load balancing multi-master replication cluster on AWS using Terraform](clustering/terraform-elb/using-terraform.md)
-    * [AllegroGraph Replication using NGINX Load Balancer](clustering/misc/using-nginx-load-balancer.md)
-    * [MMR Replication Clusters in Kubernetes and Docker Swarm](clustering/kubernetes/mmr/kubernetes-mmr.md)
-* Data examples
-  * [Bitcoin RDF model](data/bitcoin)
+### Goals ###
+1. Creating a docker image like [Docker and AllegroGraph 7.0.4](https://franz.com/agraph/support/documentation/current/docker.html) but for [Multi-Master Replication in AllegroGraph 7.0.4](https://franz.com/agraph/support/documentation/current/multi-master.html) based on [Welcome to AllegroGraph examples](https://github.com/franzinc/agraph-examples).
 
-* Generate AllegroGraph databases
-  * [Weather data](generators/weather/weather.md)
-  
+1. Run standardized Multi-master Replication in AllegroGraph 7.0.4 using [Google Kubernetes Engine, GKE](https://cloud.google.com/kubernetes-engine).
+
+1. Make it available for semantic AI research studies with help of [Google's Free Tier ](https://cloud.google.com/free) and [AllegroGraph's Free Editon ](https://allegrograph.com/) and to learn more about both products.
+
+1. Setup a Kubernetes namespace `agraph-ns`,  Kubernetes `Update-Strategy` and the `Horizontal Pod AutoScaler, HPA` e.g. using `Google's Cluster Autoscaler`. 
+
+
+### Affected Parts ###
+
+Therefore, only the clustering parts of **docker** (folders: ``clustering/kubernetes/mmr/agmmr/*``), **kubernetes** and **helm** (folders: ``clustering/kubernetes/mmr/helm/*``) has been changed. 
+
+## Important Constraints !!! ##
+Currently ...
+* ... it's only a **developer study** version and it's **not ready for production!** 
+* ... the prototype was only running in a **very small (free)** Google GKE **test environment**.
+* ... **fundamental changes** had been made (e.g. from ``StateFull`` copy read only ``pods`` to ``Deployment`` copy read only ``pods``) and Kubernetes' ``Horizontal Pod Autoscaler`` had been defined added (``hpa.yaml``).
+
+## Known Issue ##
+After deployment, sometimes it may happen, that the repositories are not reachable by the `agraph-mmr-copy-loadbalancer`. That's because the `agraph-mmr-controlling` stateful set has to run   before the `agraph-mmr-copy` deployment. I haven't figured out yet, how to arrange a sequential start in Helm. 
+
+You can **circumvent** the issue by deleting the `agraph-mmr-copy` pods in the Google Cloud Console or you can perform a graceful pod deletion with the following command:
+
+`kubectl delete pods \<pod>`
+
+The `agraph-mmr-copy` pods will be recreated automatically by the deploment.  
+
+---
+## ToDo's for a Reliable Release
+1. Change Helm to always start the stateful set `agraph-mmr-controlling` before the  `agraph-mmr-copy` deployment.  
+
+For a reliable release of the Docker Image 7.0.4 together with Kubernetes and Helm, it's important to validate and test ...
+1. ... the functionality of `copy-ssl.yaml` pods after the change from `StatefulSet` to Kubernetes `Deployment` pods.
+1. ... the reliability and horizontal scalability of the pods (`hpa.yaml`) and of the Kubernetes cluster (e.g. GKE) in an operational environment with high query loads.
+1. ... the interaction of the state-oriented controller pods with the stateless copy pods.
+1. ... etc.
+---
+## Overview of Changes 
+### Affected Parts ###
+Only the clustering parts of **docker** (folders under: ``clustering/kubernetes/mmr/agmmr/*``), **kubernetes** and **helm** (folders under: ``clustering/kubernetes/mmr/helm/*``) were changed. 
+
+### Docker Image, Version 7.0.4
+*.../mmr/agmmr/Dockerfile:*
+* Changed to AllegroGraph version to 7.0.4
+* Testrelease removed
+* Changed access to `chmod +x /app/misc/runrepl.sh`
+
+*.../mmr/agmmr/Makefile:*
+* Changed to AllegroGraph version to 7.0.4
+* Testrelease removed
+
+### Helm 
+*.../mmr/helm/Makefile:*
+* Given application name `agraph-mmr`
+* Kubenretes namespace added `agraph-ns` for all components
+* Changed to AllegroGraph version to 7.0.4
+* Changed to AllegroGraph app version to 7.0.4
+
+*.../mmr/helm/agraphmmr/Chart.yaml:*
+* Changed to AllegroGraph version to 7.0.4
+* Kept the maintainers to "Franz Inc."
+
+*.../mmr/helm/agraphmmr/values.yaml:*
+* CPU limits added
+* Update behaviour added
+* Horizontal Pod Autoscaler criteria added
+
+### Kubernetes templates
+*.../mmr/helm/agraphmmr/templates/controlling-ss.yaml:*
+* Required `selector`added
+* Update strategy added
+*  CPU limits for the Horizontal Pod Autoscaler, HPA added 
+
+*.../mmr/helm/agraphmmr/templates/copy-ss.yaml:*
+* Because of read-only, stateless pods: Changed the  `kind` from `StatefulSet` to `Deploment`
+* Constant `replica` set to `1`; it's under HPA control
+* `matchLabels` and `app`added
+* Update strategy added
+* Values added under `Resources` for HPA
+
+*.../mmr/helm/agraphmmr/templates/hpa.yaml:*
+New file added for Horizontal Pod Autoscaler, HPA concerning ... 
+* the controllers (controlling-ss.yaml)
+* the workers (copy-ss.yaml) 
+

--- a/clustering/kubernetes/mmr/agmmr/Dockerfile
+++ b/clustering/kubernetes/mmr/agmmr/Dockerfile
@@ -8,17 +8,16 @@ FROM centos:7
 # ensure we have a good set of network programs installed
 RUN yum -y install net-tools iputils bind-utils wget hostname openssl
 
-ARG agversion=7.0.0
-ARG testrelease=
+ARG agversion=7.0.4  
 
 ENV agdistfile=agraph-${agversion}-linuxamd64.64.tar.gz
 ENV agversion=${agversion}
 
 ## Show the curl command we're about to execute
 ## This useful for debugging curl problems due to invalid arguments
-RUN echo will do: curl -f -o ${agdistfile} http://franz.com/ftp/pri/acl/ag/ag${agversion}${testrelease}/linuxamd64.64/${agdistfile}
+RUN echo will do: curl -f -o ${agdistfile} https://franz.com/ftp/pri/acl/ag/ag${agversion}/linuxamd64.64/${agdistfile}
 
-RUN curl -f -o ${agdistfile} http://franz.com/ftp/pri/acl/ag/ag${agversion}${testrelease}/linuxamd64.64/${agdistfile}
+RUN curl -f -o ${agdistfile} https://franz.com/ftp/pri/acl/ag/ag${agversion}/linuxamd64.64/${agdistfile}
 
 ## extract the AllegroGraph distribution
 RUN tar xfz ${agdistfile}
@@ -40,5 +39,5 @@ COPY . /app/misc
 # in the controlling instance only.
 VOLUME ["/app/rootcatalog"]
 
-
+RUN chmod +x /app/misc/runrepl.sh
 ENTRYPOINT ["/app/misc/runrepl.sh"]

--- a/clustering/kubernetes/mmr/agmmr/Makefile
+++ b/clustering/kubernetes/mmr/agmmr/Makefile
@@ -4,13 +4,12 @@
 #
 # e.g.  make agversion=6.5.0 build
 #
-dockeraccount=unspecified
-agversion=7.0.0
-testrelease=
-tag=7.0.0
+dockeraccount = unspecified
+agversion=7.0.4 
+tag=7.0.4
 
 build:
-	docker build --build-arg agversion=$(agversion) --build-arg testrelease=$(testrelease) -t  $(dockeraccount)/agmmr:$(tag) .
+	docker build -t $(dockeraccount)/agmmr:$(tag) --build-arg agversion=$(agversion) --build-arg $(dockeraccount)/agmmr:$(tag) .
 
 push:
 	docker image push $(dockeraccount)/agmmr:$(tag)

--- a/clustering/kubernetes/mmr/helm/Makefile
+++ b/clustering/kubernetes/mmr/helm/Makefile
@@ -5,8 +5,8 @@
 # to see the steps you must perform to install the cluster
 #
 
-name ?= --generate-name
-
+name = agraph-mmr
+namespace = agraph-ns
 info:
 	@echo
 	@echo You can install the mmr cluster in kubernetes
@@ -26,11 +26,20 @@ info:
 
 
 install:
-	helm install $(name) ./agraphmmr
+	helm install $(name) ./agraphmmr --create-namespace --namespace $(namespace)
+
+# rwy added:
+re-install:
+	helm upgrade --install $(name) ./agraphmmr --namespace $(namespace)
+
 
 install-with-license:
-	helm install --set-file license=$(file) $(name) ./agraphmmr
+	helm install --set-file license=$(file) $(name) ./agraphmmr --namespace $(namespace)
 
+
+# rwy added:
+uninstall:
+	helm uninstall $(name) --namespace $(namespace)
 
 ## make a Helm repository with the agraphmmr chart in it
 repository:

--- a/clustering/kubernetes/mmr/helm/agraphmmr/Chart.yaml
+++ b/clustering/kubernetes/mmr/helm/agraphmmr/Chart.yaml
@@ -7,17 +7,17 @@ home: https://github.com/franzinc/agraph-examples/tree/master/clustering/kuberne
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 7.0.0
+version: 7.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 7.0.0
+appVersion: 7.0.4
 
 icon: https://franz.com/images/logo.png
+
 
 maintainers:
  - name: "Franz Inc"
    email: "support@franz.com"
-
 
 

--- a/clustering/kubernetes/mmr/helm/agraphmmr/templates/controlling-lb.yaml
+++ b/clustering/kubernetes/mmr/helm/agraphmmr/templates/controlling-lb.yaml
@@ -17,5 +17,3 @@ spec:
     targetPort: {{ .Values.port }}
   selector:
     app: {{ .Release.Name }}-controlling
-
-

--- a/clustering/kubernetes/mmr/helm/agraphmmr/templates/controlling-ss.yaml
+++ b/clustering/kubernetes/mmr/helm/agraphmmr/templates/controlling-ss.yaml
@@ -1,14 +1,23 @@
 #
 # stateful set of controlling instance
 #
-
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ .Release.Name }}-controlling
 spec:
+  # rwy: selector added
+  selector:
+    matchLabels:
+#      # has to match .spec.template.metadata.labels
+      app: {{ .Release.Name }}-controlling
   serviceName: {{ .Release.Name }}-controlling
   replicas: 1
+  #
+  # Update Strategy
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -18,6 +27,12 @@ spec:
         - name: {{ .Release.Name }}-controlling
           image: {{ .Values.image.repository }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # CPU limits for the Horizontal Pod Autoscaler, HPA
+          resources:
+            limits:
+              cpu: {{ .Values.cpu.limit}}
+            requests:
+              cpu: {{ .Values.cpu.request}}
           livenessProbe:
             httpGet:
               path: /version
@@ -52,4 +67,3 @@ spec:
                 storage: {{ .Values.dataStorage }}
             accessModes:
             - ReadWriteOnce
-

--- a/clustering/kubernetes/mmr/helm/agraphmmr/templates/copy-lb.yaml
+++ b/clustering/kubernetes/mmr/helm/agraphmmr/templates/copy-lb.yaml
@@ -19,4 +19,3 @@ spec:
     targetPort: {{ .Values.port }}
   selector:
     app: {{ .Release.Name }}-copy
-

--- a/clustering/kubernetes/mmr/helm/agraphmmr/templates/copy-ss.yaml
+++ b/clustering/kubernetes/mmr/helm/agraphmmr/templates/copy-ss.yaml
@@ -1,43 +1,63 @@
 #
 # stateful set of copies of the copy instance
 #
-
-apiVersion: apps/v1beta1
-kind: StatefulSet
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: {{ .Release.Name }}-copy
 spec:
-  serviceName: {{ .Release.Name }}-copy
-  replicas: {{ .Values.replicas }}
+  # Replicas will be changed by Horizontal Pod Autoscaler, HPA
+  replicas: 1 
+  selector:
+    matchLabels:
+#     # has to match .spec.template.metadata.labels
+      app: {{ .Release.Name }}-copy
+#      
+# Update strategy
+  minReadySeconds: {{ .Values.update.minReadySeconds }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.update.maxSurge }}
+      maxUnavailable: {{ .Values.update.maxUnavailable }}
+    type: RollingUpdate
+#
   template:
     metadata:
       labels:
         app: {{ .Release.Name }}-copy
     spec:
-        volumes:
-         - name: shm
-           emptyDir:
-             medium: Memory
-         - name: secrets
-           secret:
-               secretName: {{ .Release.Name }}-agraphsecrets
-        containers:
-        - name: {{ .Release.Name }}-controlling
-          image: {{ .Values.image.repository }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          livenessProbe:
-            httpGet:
-              path: /version
-              port: {{ .Values.port }}
-            initialDelaySeconds: 30
-          volumeMounts:
-          - name: shm
-            mountPath: /dev/shm
-          - name: secrets
-            mountPath: /app/secrets
-            readOnly: true
-          env:
-          - name: ControllingHost
-            value: "{{ .Release.Name }}-controlling"
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+        - name: secrets
+          secret:
+            secretName: {{ .Release.Name }}-agraphsecrets
+      containers:
+      - name: {{ .Release.Name }}-controlling
+        image: {{ .Values.image.repository }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        # CPU limits for the Horizontal Pod Autoscaler, HPA
+        resources:
+          limits:
+            cpu: {{ .Values.cpu.limit}}
+          requests:
+            cpu: {{ .Values.cpu.request}}
+        # Pod still available ?
+        livenessProbe:
+          httpGet:
+            path: /version
+            port: {{ .Values.port }}
+          initialDelaySeconds: 30
+        # Mount need application volumes
+        volumeMounts:
+        - name: shm
+          mountPath: /dev/shm
+        - name: secrets
+          mountPath: /app/secrets
+          readOnly: true
+        env:
+        - name: ControllingHost
+          value: "{{ .Release.Name }}-controlling"
 
 

--- a/clustering/kubernetes/mmr/helm/agraphmmr/templates/hpa.yaml
+++ b/clustering/kubernetes/mmr/helm/agraphmmr/templates/hpa.yaml
@@ -1,0 +1,26 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-copy-hpa
+spec:
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-copy
+  targetCPUUtilizationPercentage: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+  
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-controlling-hpa
+spec:
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ .Release.Name }}-controlling
+  targetCPUUtilizationPercentage: {{ .Values.hpa.targetCPUUtilizationPercentage }}

--- a/clustering/kubernetes/mmr/helm/agraphmmr/values.yaml
+++ b/clustering/kubernetes/mmr/helm/agraphmmr/values.yaml
@@ -15,17 +15,12 @@
 #    IfNotPresent - use this when Docker image is stable
 # 
 image:
-  repository: franzinc/agmmr:7.0.0
-  pullPolicy: IfNotPresent
-
-# replicas is the number of AllegroGraph servers to start up that will join the cluster
-# and replicate the repository of the controlling instance.
-replicas: 2
+ repository: franzinc/agmmr:7.0.4
+ pullPolicy: IfNotPresent
 
 # dataStorage is the amount of persistent storage space to allocate for the controlling instance's
 # repository data.   
 dataStorage: 20Gi
-
 
 # these values are put in a secrets file
 # user is the username of the admin account for the AllegroGraph server
@@ -37,6 +32,31 @@ port: 10035
 # reponame is the name of the repository in the root catalog on the controlling instance
 #  that will be replicated in each of replicas
 reponame: myrepl
+
+# Container deployment pod CPU limits
+cpu:
+  limit:  1
+  request: 0.7
+
+# Pod update behaviour; update strategy values
+update:
+    # the bootup time of your application, Kubernetes waits specific time til the next pod creation.
+    minReadySeconds: 10
+    # ex. maxSurge: 1 means that there will be at most 4 pods during the update process if replicas is 3
+    maxSurge: 1
+    # ex. maxUnavailable: 1 means that there will be at most 1 pod unavailable during the update process
+    maxUnavailable: 0
+
+
+
+# replicas is the number of AllegroGraph servers to start up that will join the cluster
+# and replicate the repository of the controlling instance.
+# Horizontal Auto Scaler for deployment ...copy-ss...
+hpa:
+  minReplicas: 1 # min deployment pods
+  maxReplicas: 5 # max deployment pods
+  # Start deployment pod if targetCPUUtilizationPercentage*cpu-request => spin a new pod
+  targetCPUUtilizationPercentage: 90
 #
 # to insert the AllegroGraph license here you must
 # use the yaml conventions for a multi-line value.


### PR DESCRIPTION
_Excerpt from the README.md file ..._

## Introduction 
### Based on ###
 This is an extension of the product "AllegroGraph for Multi-Master Replication" and is based on https://github.com/franzinc/agraph-examples.

### Goals ###
## Introduction 
### Based on ###
 This is an extension of the product "AllegroGraph for Multi-Master Replication" and is based on https://github.com/franzinc/agraph-examples.

### Goals ###
1. Creating a docker image like [Docker and AllegroGraph 7.0.4](https://franz.com/agraph/support/documentation/current/docker.html) but for [Multi-Master Replication in AllegroGraph 7.0.4](https://franz.com/agraph/support/documentation/current/multi-master.html) based on [Welcome to AllegroGraph examples](https://github.com/franzinc/agraph-examples).

1. Run standardized Multi-master Replication in AllegroGraph 7.0.4 using [Google Kubernetes Engine, GKE](https://cloud.google.com/kubernetes-engine).

1. Make it available for semantic AI research studies with help of [Google's Free Tier ](https://cloud.google.com/free) and [AllegroGraph's Free Editon ](https://allegrograph.com/) and to learn more about both products.

1. Setup a Kubernetes namespace `agraph-ns`,  Kubernetes `Update-Strategy` and the `Horizontal Pod AutoScaler, HPA` e.g. using `Google's Cluster Autoscaler`. 
2. 
_... you can find more about in the README.md file._
